### PR TITLE
Add file browser

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -27,16 +27,14 @@ jobs:
           pre-commit run --all-files
 
   pytest:
-    name: Pytest ${{ matrix.config.name }}
+    name: Pytest ${{ matrix.config.name }} ${{ matrix.python-version }}
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
         config:
           - { name: "Linux", os: ubuntu-latest }
-          - { name: "MacOSX", os: macos-latest }
-          - { name: "Windows", os: windows-latest }
 
     defaults:
       run:
@@ -51,10 +49,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install system dependencies
+        if: matrix.config.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libsdl2-ttf-2.0-0 \
+            libsdl2-2.0-0
+
       - name: Install and Run Tests
         run: |
-          pip install ".[dev]"
-          pytest -s ./tests
+          python -m pip install --upgrade pip
+          python -m pip install ".[dev]"
+          python -m pytest -s tests
 
   release:
     needs: [pre-commit, pytest]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install ".[turbo]"
 ## Run trame application
 
 ```
-girdereegviewer file.neonatal
+girdereegviewer
 ```
 
 To test the application, you can try to use the

--- a/girdereegviewer/__main__.py
+++ b/girdereegviewer/__main__.py
@@ -1,4 +1,4 @@
-from .core import ViewerApp
+from girdereegviewer.core import ViewerApp
 
 
 def main(**kwargs) -> None:

--- a/girdereegviewer/core.py
+++ b/girdereegviewer/core.py
@@ -32,7 +32,7 @@ class ViewerApp(TrameApp):
         self._file_browser_logic = FileBrowserLogic(self.server)
         self._eeg_viewer_logic = EEGViewerLogic(self.server)
 
-        self._file_browser_logic.files_selected.connect(self._eeg_viewer_logic.set_file_path)
+        self._file_browser_logic.eeg_files_selected.connect(self._eeg_viewer_logic.set_file_path)
         self.layout = ViewerLayout(self.server)
         self._build_ui()
 

--- a/girdereegviewer/core.py
+++ b/girdereegviewer/core.py
@@ -5,6 +5,7 @@ from trame.widgets import vuetify3 as v3
 from trame_server.core import Server
 
 from .eeg import EEGViewerLogic, EEGViewerUI
+from .file_browser import FileBrowserLogic, FileBrowserUI
 
 
 class ViewerLayout(VAppLayout):
@@ -27,10 +28,11 @@ class ViewerLayout(VAppLayout):
 class ViewerApp(TrameApp):
     def __init__(self):
         super().__init__()
-        self.server.cli.add_argument("path")  # Will not be used once girder/filebrowser is set up
-        args, _ = self.server.cli.parse_known_args()
 
-        self._eeg_viewer_logic = EEGViewerLogic(args.path)  # Will not be used once girder/filebrowser is set up
+        self._file_browser_logic = FileBrowserLogic(self.server)
+        self._eeg_viewer_logic = EEGViewerLogic(self.server)
+
+        self._file_browser_logic.files_selected.connect(self._eeg_viewer_logic.set_file_path)
         self.layout = ViewerLayout(self.server)
         self._build_ui()
 
@@ -38,8 +40,12 @@ class ViewerApp(TrameApp):
 
     def _build_ui(self) -> None:
         with self.layout:
-            client.Style("html { overflow-y: hidden; } ")
+            client.Style(
+                "html { overflow-y: hidden; } "
+                ".v-input .v-input__prepend .v-icon { color: rgb(var(--v-theme-on-surface)); opacity: 1; }"
+            )
             with self.layout.app_bar:
+                self._file_browser_ui = FileBrowserUI()
                 v3.VAppBarTitle(self.state.trame__title, style="flex: 0 1 auto;")
 
             with self.layout.app_viewer:
@@ -47,3 +53,4 @@ class ViewerApp(TrameApp):
 
     def set_ui(self) -> None:
         self._eeg_viewer_logic.set_ui(self._eeg_viewer_ui)
+        self._file_browser_logic.set_ui(self._file_browser_ui)

--- a/girdereegviewer/eeg/eeg_viewer_logic.py
+++ b/girdereegviewer/eeg/eeg_viewer_logic.py
@@ -1,10 +1,20 @@
+from trame_rca.utils import RcaViewAdapter
+from trame_server import Server
+
 from .eeg_viewer_ui import EEGViewerUI
 from .eeg_viewer_window import EEGViewerWindow
 
 
 class EEGViewerLogic:
-    def __init__(self, data_path: str):
-        self.eeg_window = EEGViewerWindow(data_path)
+    view_handler: RcaViewAdapter
+
+    def __init__(self, server: Server):
+        self.server = server
+        self.eeg_window = EEGViewerWindow()
 
     def set_ui(self, ui: EEGViewerUI) -> None:
-        ui.create_view_handler(self.eeg_window)
+        self.view_handler = ui.create_view_handler(self.eeg_window)
+
+    def set_file_path(self, file_path: str) -> None:
+        self.eeg_window.set_file_path(file_path)
+        self.view_handler.update_size(None, self.eeg_window.window_size)

--- a/girdereegviewer/eeg/eeg_viewer_window.py
+++ b/girdereegviewer/eeg/eeg_viewer_window.py
@@ -8,20 +8,30 @@ from trame_rca.utils import AbstractWindow
 
 
 class EEGViewerWindow(AbstractWindow):
-    def __init__(self, data_path: str):
-        if not Path(data_path).exists():
-            raise Exception("Path does not exist")
-        self._context = libeegviz.create(data_path)
+    def __init__(self):
+        self._context = None
         self._events = ["MouseMove", "LeftButtonPress", "RightButtonPress", "KeyDown"]
         self._cols, self._rows = 0, 0
+        self.window_size = {"w": 0, "h": 0}
+
+    def set_file_path(self, file_path: str) -> None:
+        if not Path(file_path).exists():
+            raise Exception("Path does not exist")
+        self._context = libeegviz.create(file_path)
 
     def _move(self, x: float, y: float) -> None:
+        if self._context is None:
+            return
         libeegviz.move(self._context, x, y)
 
     def _click(self, button: str) -> None:
+        if self._context is None:
+            return
         libeegviz.click(self._context, button)
 
     def _keydown(self, key: str) -> None:
+        if self._context is None:
+            return
         libeegviz.key(self._context, key)
 
     def _is_point_in_window(self, x: float, y: float) -> None:
@@ -37,7 +47,9 @@ class EEGViewerWindow(AbstractWindow):
         return (out_rgb * 255).astype(np.uint8)
 
     @property
-    def img_cols_rows(self) -> None:
+    def img_cols_rows(self) -> tuple[Any, int, int]:
+        if self._context is None:
+            return (None, 0, 0)
         byte_image, self._cols, self._rows, _ = libeegviz.update(self._context)
         image = Image.frombytes(mode="RGBA", size=(self._cols, self._rows), data=byte_image)
         np_image = np.asarray(image)
@@ -49,6 +61,9 @@ class EEGViewerWindow(AbstractWindow):
         )
 
     def process_resize_event(self, width: int, height: int) -> None:
+        self.window_size = {"w": width, "h": height}
+        if self._context is None:
+            return
         libeegviz.resize(self._context, width, height)
 
     def process_interaction_event(self, event: Any) -> None:

--- a/girdereegviewer/file_browser/__init__.py
+++ b/girdereegviewer/file_browser/__init__.py
@@ -1,0 +1,4 @@
+from .file_browser_logic import FileBrowserLogic
+from .file_browser_ui import FileBrowserUI
+
+__all__ = ["FileBrowserLogic", "FileBrowserUI"]

--- a/girdereegviewer/file_browser/file_browser_logic.py
+++ b/girdereegviewer/file_browser/file_browser_logic.py
@@ -6,27 +6,149 @@ from trame_server import Server
 from trame_server.utils.typed_state import TypedState
 from undo_stack import Signal
 
-from .file_browser_ui import FileBrowserState, FileBrowserUI
+from .file_browser_ui import File, FileBrowserState, FileBrowserUI
+
+ANNOTATION_FILE_SUFFIX = "annotations.csv"
+
+
+class FileValidationError(Exception):
+    pass
+
+
+class EEGLoadingError(Exception):
+    pass
+
+
+def are_files_valid(files: list[dict[str, Any]]) -> bool:
+    return all(isinstance(file.get("name"), str) and isinstance(file.get("content"), bytes) for file in files)
 
 
 class FileBrowserLogic:
-    files_selected = Signal(str)
+    eeg_files_selected = Signal(str)
 
     def __init__(self, server: Server):
         self.server = server
         self.typed_state = TypedState(self.server.state, FileBrowserState)
+        self._current_tmpdir: tempfile.TemporaryDirectory[str] | None = None
+
+    @property
+    def name(self) -> str:
+        return self.typed_state.name
+
+    @property
+    def data(self) -> FileBrowserState:
+        return self.typed_state.data
 
     def set_ui(self, ui: FileBrowserUI) -> None:
         ui.files_selected.connect(self._load_files)
+        ui.save_clicked.connect(self._save_eeg_annotations)
 
-    def _load_files(self, selected_files: list[Any], loading_name: str) -> None:
-        if len(selected_files) == 1:
-            selected_file = selected_files[0]
-            with tempfile.TemporaryDirectory() as tmpdir:
-                file_path = Path(tmpdir) / selected_file["name"]
-                content = selected_file["content"]
-                with file_path.open("wb") as f:
-                    f.write(content)
-                self.files_selected(str(file_path))
+    def _cleanup_current_tmpdir(self) -> None:
+        if self._current_tmpdir is not None:
+            self._current_tmpdir.cleanup()
+            self._current_tmpdir = None
 
-        self.server.state[loading_name] = False
+    def _create_tmp_dir(self) -> None:
+        self._cleanup_current_tmpdir()
+        self._current_tmpdir = tempfile.TemporaryDirectory()
+
+    def _write_file(self, file_path: Path, file_content: bytes) -> None:
+        try:
+            file_path.write_bytes(file_content)
+        except OSError as e:
+            raise OSError(f"Could not write file: {file_path}") from e
+
+    def _write_file_to_tmp_dir(self, file: File) -> str:
+        if self._current_tmpdir is None:
+            raise RuntimeError("Temporary directory is not initialized")
+
+        file_path = Path(self._current_tmpdir.name) / file.name
+
+        self._write_file(file_path, file.content)
+
+        return str(file_path)
+
+    def _validate_eeg_files(self, eeg_files: list[dict[str, Any]]) -> None:
+        if not eeg_files:
+            raise FileValidationError("No files selected")
+
+        if len(eeg_files) > 2:
+            raise FileValidationError("Too many files selected")
+
+        if not are_files_valid(eeg_files):
+            raise FileValidationError("Invalid file format")
+
+        eeg_files.sort(key=lambda d: d["name"])
+
+        self.data.eeg_file = File(
+            name=eeg_files[0]["name"],
+            content=eeg_files[0]["content"],
+        )
+
+        annotation_file_name = f"{self.data.eeg_file.name}.{ANNOTATION_FILE_SUFFIX}"
+
+        has_annotation_file = len(eeg_files) == 2 and eeg_files[1]["name"] == annotation_file_name
+
+        self.data.eeg_annotation_file = File(
+            name=annotation_file_name,
+            content=eeg_files[1]["content"] if has_annotation_file else None,
+        )
+
+    def _load_eeg_files(self) -> None:
+        if self.data.eeg_file is None:
+            raise EEGLoadingError("EEG file is missing")
+
+        self._create_tmp_dir()
+
+        eeg_file_path = self._write_file_to_tmp_dir(self.data.eeg_file)
+
+        if self.data.eeg_annotation_file.content is not None:
+            self._write_file_to_tmp_dir(self.data.eeg_annotation_file)
+
+        try:
+            self.eeg_files_selected(eeg_file_path)
+        except Exception as e:
+            raise EEGLoadingError("Could not load data into EEG Viewer") from e
+
+    def _reset_state(self) -> None:
+        self.data.eeg_file = None
+        self.data.eeg_annotation_file = None
+
+    def _load_files(self, selected_files: list[dict[str, Any]]) -> None:
+        try:
+            self._validate_eeg_files(selected_files)
+            self._load_eeg_files()
+
+        except FileValidationError:
+            self._reset_state()
+            raise
+
+        except EEGLoadingError:
+            self._reset_state()
+            raise
+
+        finally:
+            self.data.loading = False
+
+    def _save_eeg_annotations(self) -> None:
+        if self._current_tmpdir is None:
+            raise RuntimeError("Temporary directory is not initialized")
+
+        annotation_file = self.data.eeg_annotation_file
+
+        if annotation_file is None:
+            raise RuntimeError("Annotation file is missing")
+
+        annotation_file_name = annotation_file.name
+
+        tmp_annotation_file_path = Path(self._current_tmpdir.name) / annotation_file_name
+
+        if not tmp_annotation_file_path.exists():
+            raise FileNotFoundError(f"Annotation file does not exist: {tmp_annotation_file_path}")
+
+        save_annotation_file_path = Path.cwd() / annotation_file_name
+
+        self._write_file(
+            save_annotation_file_path,
+            tmp_annotation_file_path.read_bytes(),
+        )

--- a/girdereegviewer/file_browser/file_browser_logic.py
+++ b/girdereegviewer/file_browser/file_browser_logic.py
@@ -1,0 +1,32 @@
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from trame_server import Server
+from trame_server.utils.typed_state import TypedState
+from undo_stack import Signal
+
+from .file_browser_ui import FileBrowserState, FileBrowserUI
+
+
+class FileBrowserLogic:
+    files_selected = Signal(str)
+
+    def __init__(self, server: Server):
+        self.server = server
+        self.typed_state = TypedState(self.server.state, FileBrowserState)
+
+    def set_ui(self, ui: FileBrowserUI) -> None:
+        ui.files_selected.connect(self._load_files)
+
+    def _load_files(self, selected_files: list[Any], loading_name: str) -> None:
+        if len(selected_files) == 1:
+            selected_file = selected_files[0]
+            with tempfile.TemporaryDirectory() as tmpdir:
+                file_path = Path(tmpdir) / selected_file["name"]
+                content = selected_file["content"]
+                with file_path.open("wb") as f:
+                    f.write(content)
+                self.files_selected(str(file_path))
+
+        self.server.state[loading_name] = False

--- a/girdereegviewer/file_browser/file_browser_ui.py
+++ b/girdereegviewer/file_browser/file_browser_ui.py
@@ -8,37 +8,60 @@ from undo_stack import Signal
 
 
 @dataclass
+class File:
+    name: str
+    content: bytes | None = None
+
+
+@dataclass
 class FileBrowserState:
-    loading_busy: bool = False
+    loading: bool = False
     display_button_tooltip: bool = False
+    eeg_file: File | None = None
+    eeg_annotation_file: File | None = None
 
 
 class FileBrowserUI(html.Div):
-    files_selected = Signal(list[Any], str)
+    files_selected = Signal(list[dict[str, Any]])
+    save_clicked = Signal()
 
     def __init__(self):
-        super().__init__(classes="d-flex flex-row justify-center align-center", style="width: 50px; height: 50px;")
+        super().__init__(classes="d-flex flex-row align-center")
         self.typed_state = TypedState(self.state, FileBrowserState)
+        self._build_ui()
 
+    def _build_ui(self) -> None:
         with self:
-            v3.VTooltip(
-                v_model=(self.typed_state.name.display_button_tooltip,),
-                text="Load file",
-                activator="parent",
-                transition="slide-y-transition",
-                location="bottom start",
-            )
-            v3.VFileInput(
-                v_if=(f"!{self.typed_state.name.loading_busy}",),
-                change=(
-                    f"{self.typed_state.name.loading_busy} = true; {self.typed_state.name.display_button_tooltip} = false;"
-                    "trigger('"
-                    f"{self.ctrl.trigger_name(self.files_selected)}"
-                    f"', [$event.target.files, '{self.typed_state.name.loading_busy}']"
-                    ")"
-                ),
-                prepend_icon="mdi-file-plus-outline",
-                multiple=False,
-                hide_input=True,
-            )
-            v3.VProgressCircular(v_else=True, indeterminate=True, size=24)
+            with html.Div(classes="d-flex flex-row justify-center align-center", style="width: 50px; height: 50px;"):
+                v3.VTooltip(
+                    v_model=(self.typed_state.name.display_button_tooltip,),
+                    text="Load file",
+                    activator="parent",
+                    transition="slide-y-transition",
+                    location="bottom start",
+                )
+                v3.VFileInput(
+                    v_if=(f"!{self.typed_state.name.loading}",),
+                    change=(
+                        f"{self.typed_state.name.loading} = true; {self.typed_state.name.display_button_tooltip} = false; "
+                        f"trigger('{self.ctrl.trigger_name(self.files_selected)}', [$event.target.files]);"
+                    ),
+                    prepend_icon="mdi-file-plus-outline",
+                    multiple=True,
+                    hide_input=True,
+                )
+                v3.VProgressCircular(v_else=True, indeterminate=True, size=24)
+
+            with html.Div(classes="d-flex flex-row justify-center align-center", style="width: 50px; height: 50px;"):
+                v3.VTooltip(
+                    v_if=(self.typed_state.name.eeg_annotation_file,),
+                    text="Save annotations",
+                    activator="parent",
+                    transition="slide-y-transition",
+                    location="bottom start",
+                )
+                v3.VBtn(
+                    click=self.save_clicked,
+                    disabled=(f"!{self.typed_state.name.eeg_annotation_file}",),
+                    icon="mdi-content-save-outline",
+                )

--- a/girdereegviewer/file_browser/file_browser_ui.py
+++ b/girdereegviewer/file_browser/file_browser_ui.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from typing import Any
+
+from trame.widgets import html
+from trame.widgets import vuetify3 as v3
+from trame_server.utils.typed_state import TypedState
+from undo_stack import Signal
+
+
+@dataclass
+class FileBrowserState:
+    loading_busy: bool = False
+    display_button_tooltip: bool = False
+
+
+class FileBrowserUI(html.Div):
+    files_selected = Signal(list[Any], str)
+
+    def __init__(self):
+        super().__init__(classes="d-flex flex-row justify-center align-center", style="width: 50px; height: 50px;")
+        self.typed_state = TypedState(self.state, FileBrowserState)
+
+        with self:
+            v3.VTooltip(
+                v_model=(self.typed_state.name.display_button_tooltip,),
+                text="Load file",
+                activator="parent",
+                transition="slide-y-transition",
+                location="bottom start",
+            )
+            v3.VFileInput(
+                v_if=(f"!{self.typed_state.name.loading_busy}",),
+                change=(
+                    f"{self.typed_state.name.loading_busy} = true; {self.typed_state.name.display_button_tooltip} = false;"
+                    "trigger('"
+                    f"{self.ctrl.trigger_name(self.files_selected)}"
+                    f"', [$event.target.files, '{self.typed_state.name.loading_busy}']"
+                    ")"
+                ),
+                prepend_icon="mdi-file-plus-outline",
+                multiple=False,
+                hide_input=True,
+            )
+            v3.VProgressCircular(v_else=True, indeterminate=True, size=24)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 dependencies = [
     "eegvizlib",
     "girder-client",
+    "py-undo-stack",
     "trame>=3.8.0",
     "trame-gwc",
     "trame-server",


### PR DESCRIPTION
Add file system browser with VFileInput
Save selected files to a tmp dir which stays available until another data is loaded.
Annotations files (selected or automatically created by the EEG viewer) are also in the same tmp dir.
Annotations files can be saved to current dir (may be reopen a file browser to choose the dir to save it to?)

Change:
the app does not take any argument anymore
we can switch data without re-running the app

Fix:
Add the .github folder so the CI is actually set...